### PR TITLE
Update synochat.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Synochat Appimage Builder
+
+Since the Synology Chat Client application is currently broken on Fedora 33 due to it's dependency 'scrot' no longer being maintained as well as on Ubuntu 20.04 because of an [issue with the underlying electron framework](https://github.com/electron/electron/issues/20348), I decided to package the application as an AppImage, that should work on any Linux Distro out there (confirmed on Fedora 33 and Ubuntu 20.04). Since I *do not have any copyright on this application* I won't publish the working AppImage, but instead help you building it yourself
+
+## Build Instructions
+
+The build process is pretty easy. Simply download the [deb2appimage tool](https://github.com/simoniz0r/deb2appimage) and install it's dependencies \(I've used the AppImage version\), execute it and set the `synochat.json` contained in this very repository as config file.
+
+Your commands should look like this:
+
+```bash
+chmod +x deb2appimage*.AppImage
+./deb2appimage*.AppImage -j synochat.json
+```
+
+This will create you a synochat-linux.AppImage, that you can again execute by typing
+
+```bash
+chmod +x synochat-linux*.AppImage
+./synochat-linux*.AppImage
+```
+
+I hope Synology will fix this issue in the future, so this workaround isn't required anymore.

--- a/synochat.json
+++ b/synochat.json
@@ -1,0 +1,48 @@
+{
+    "buildinfo": [
+    {
+        "prerun": [
+            "curl -sL https://global.download.synology.com/download/Tools/ChatClient/1.1.1-57/Ubuntu/x86_64/Chat_1.1.1-57_amd64.deb -o ~/.cache/deb2appimage/debs/synochat-linux.deb"
+        ],
+        "name": "synochat",
+        "version": "linux",
+        "deps": "scrot,libgconf-2-4,libappindicator1,libpangocairo-1.0-0,libpango-1.0-0,libpangoft2-1.0-0",
+        "repoarch": "amd64",
+        "distrorepo": "Debian",
+        "repoversion": "buster-backports,buster",
+        "binarypath": "/opt/Synology Chat/synochat",
+        "desktoppath": "/usr/share/applications/synochat.desktop",
+        "iconpath": "/usr/share/icons/hicolor/256x256/apps/synochat.png",
+        "usewrapper": "false",
+        "postrun": [
+            null
+        ]
+    }
+    ],
+    "apprunconf": [
+    {
+        "setpath": "true",
+        "setlibpath": "true",
+        "setpythonpath": "false",
+        "setpythonhome": "false",
+        "setpythondontwritebytecode": "false",
+        "setxdgdatadirs": "false",
+        "setperllib": "false",
+        "setgsettingsschemadir": "false",
+        "setqtpluginpath": "false",
+        "exec": "/opt/Synology Chat/synochat"
+    }
+    ],
+    "authors": [
+    {
+        "type": "Author",
+        "author": "Synology",
+        "url": "https://synology.com"
+    },
+    {
+        "type": "AppImage Maintainer",
+        "author": "p-fruck",
+        "url": "https://github.com/p-fruck"
+    }
+    ]
+}

--- a/synochat.json
+++ b/synochat.json
@@ -2,14 +2,14 @@
     "buildinfo": [
     {
         "prerun": [
-            "curl -sL https://global.download.synology.com/download/Tools/ChatClient/1.1.1-57/Ubuntu/x86_64/Chat_1.1.1-57_amd64.deb -o ~/.cache/deb2appimage/debs/synochat-linux.deb"
+            "curl -sL https://global.download.synology.com/download/Utility/ChatClient/1.2.1-0207/Ubuntu/x86_64/Synology%20Chat%20Client-1.2.1-0207.deb -o ~/.cache/deb2appimage/debs/synochat-linux.deb"
         ],
         "name": "synochat",
         "version": "linux",
-        "deps": "scrot,libgconf-2-4,libappindicator1,libpangocairo-1.0-0,libpango-1.0-0,libpangoft2-1.0-0",
+        "deps": "scrot,libgconf-2-4,libappindicator1,libpangocairo-1.0-0,libpango-1.0-0,libpangoft2-1.0-0,libgtk-3-0",
         "repoarch": "amd64",
         "distrorepo": "Debian",
-        "repoversion": "buster-backports,buster",
+        "repoversion": "bullseye,buster",
         "binarypath": "/opt/Synology Chat/synochat",
         "desktoppath": "/usr/share/applications/synochat.desktop",
         "iconpath": "/usr/share/icons/hicolor/256x256/apps/synochat.png",


### PR DESCRIPTION
This are the modifications needed to use the newer version, of synology chat. And this works on fedora 36